### PR TITLE
Fixed assumpion issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ distance.matrix(origins, destinations, function (err, distances) {
             for (var j = 0; j < destinations.length; j++) {
                 var origin = distances.origin_addresses[i];
                 var destination = distances.destination_addresses[j];
-                if (distances.rows[0].elements[j].status == 'OK') {
+                if (distances.rows[i].elements[j].status == 'OK') {
                     var distance = distances.rows[i].elements[j].distance.text;
                     console.log('Distance from ' + origin + ' to ' + destination + ' is ' + distance);
                 } else {

--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@ function onMatrix(err, distances) {
             for (var j = 0; j < destinations.length; j++) {
                 var origin = distances.origin_addresses[i];
                 var destination = distances.destination_addresses[j];
-                if (distances.rows[0].elements[j].status == 'OK') {
+                if (distances.rows[i].elements[j].status == 'OK') {
                     var distance = distances.rows[i].elements[j].distance.text;
                     console.log('Distance from ' + origin + ' to ' + destination + ' is ' + distance);
                 } else {


### PR DESCRIPTION
The example assumes that if `distances.rows[0].elements[j].status` is 'OK', then every other distance in the row should be okay as well, which isn't always the case. 
In some cases, `distances.rows[0].elements[j].status` returns `{ status: 'ZERO_RESULTS' }`.